### PR TITLE
Add tzdata package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     addgroup --gid 248 core-systemd-journal && \
     adduser core core-systemd-journal && \
     # Install needed packages
-    apt-get install -y sudo net-tools inetutils-ping bash-completion mc tmux openssh-client && \
+    apt-get install -y tzdata sudo net-tools inetutils-ping bash-completion mc tmux openssh-client && \
     apt-get clean && \
     # This is needed by host docker
     ln -s /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     addgroup --gid 248 core-systemd-journal && \
     adduser core core-systemd-journal && \
     # Install needed packages
-    apt-get install -y tzdata sudo net-tools inetutils-ping bash-completion mc tmux openssh-client && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata sudo net-tools inetutils-ping bash-completion mc tmux openssh-client && \
     apt-get clean && \
     # This is needed by host docker
     ln -s /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 && \


### PR DESCRIPTION
In the hope of fixing this error:

    core@kube-kubectl-us-east-1-dan-01 ~ $ toolbox
    Timezone UTC does not exist in container, not updating container timezone.

We tried bind mounting the `/usr/share/zoneinfo` directory from the host
but it didn't work. Our guess is that this happens too late.