### PR TITLE
Fix empty continuation error from Docker build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2
 
 ccc: &ccc circleci/command-convenience:0.1
+docker_version: &docker_version 18.09.3
 
 workflows:
   version: 2
@@ -30,7 +31,8 @@ jobs:
           DOCKER_REGISTRY: none
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *docker_version
       - run: publish
 
   publish:
@@ -45,5 +47,6 @@ jobs:
           DOCKER_REGISTRY: dockerhub
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: *docker_version
       - run: publish


### PR DESCRIPTION
This was appearing in the build output:

    [WARNING]: Empty continuation line found in:
        RUN     apt-get update && apt-get upgrade -y &&     addgroup --gid 500 core &&     adduser --home /home/core --shell /bin/bash --uid 500 --gid 500 --disabled-password --system core &&     addgroup --gid 253 fleet &&     adduser core fleet &&     addgroup --gid 233 coredocker &&     adduser core coredocker &&     addgroup --gid 248 core-systemd-journal &&     adduser core core-systemd-journal &&     DEBIAN_FRONTEND=noninteractive apt-get install -y tzdata sudo net-tools inetutils-ping bash-completion mc tmux openssh-client &&     apt-get clean &&     ln -s /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /lib/x86_64-linux-gnu/libdevmapper.so.1.02 &&     sed -i "s/%!s(MISSING)udo\s*ALL=(ALL:ALL)\s*ALL/%!s(MISSING)udo ALL=(ALL:ALL) NOPASSWD:ALL/" /etc/sudoers &&     adduser core sudo &&     mv /etc/bash.bashrc /etc/bash.basrc.coreos &&     echo ". /etc/bash.bashrc.coreos\nPS1=\"\\[\\033[01;35m\\]toolbox\\[\\033[01;34m\\] \$PS1\"" >/etc/bash.bashrc
    [WARNING]: Empty continuation lines will become errors in a future release.

This should be fixed by using a later version of Docker to build per
moby/moby#35004